### PR TITLE
Fix Sonarqube error in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ addons:
 
 script:
 # other script steps
-- ./gradlew sonarqube
+- ./gradlew sonarqube -Dsonar.projectKey=$SONAR_PROJECT_KEY -Dsonar.organization=$SONAR_ORG -Dsonar.host.url=$SONAR_URL


### PR DESCRIPTION
Fixes #7 issue with Sonarqube using the wrong, default URL to upload code changes.