### PR TITLE
Dockerize CockroachDB with Flyway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.5'
+
+services:
+  flyway:
+    image: boxfuse/flyway:5.2.1
+    command: -url=jdbc:postgresql://db:26257/testdb?sslmode=disable -user=user17 -password= -connectRetries=60 migrate
+    volumes:
+      - ./src/main/resources/db/migration:/flyway/sql
+    depends_on:
+      - db
+      - db-init
+    networks:
+      - roachnet
+  db:
+    image: cockroachdb/cockroach:v2.1.4
+    command: start --insecure
+    expose:
+      - "8080"
+      - "26257"
+    ports:
+      - "26257:26257"
+      - "8080:8080"
+    networks:
+      - roachnet
+  db-init:
+    image: cockroachdb/cockroach:v2.1.4
+    networks:
+      - roachnet
+    volumes:
+      - ./setup_db.sh:/setup_db.sh
+    entrypoint: "/bin/bash"
+    command: /setup_db.sh
+    depends_on:
+      - db
+networks:
+  roachnet:

--- a/setup_db.sh
+++ b/setup_db.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#echo "Wait for servers to be up"
+#sleep 10
+
+HOSTPARAMS="--host db --insecure"
+SQL="/cockroach/cockroach.sh sql $HOSTPARAMS"
+
+$SQL -e "CREATE DATABASE testdb;"
+$SQL -e "CREATE USER user17;"
+$SQL -e "GRANT ALL ON DATABASE testdb TO user17"


### PR DESCRIPTION
Closes #5. 

Using docker-compose to setup Cockroach DB and migrate Flyway schemas.